### PR TITLE
Change "MacOS-X" to "macOS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ nbase - NetBSD userlevel portable to other UNIX-like systems
 
 ## DESCRIPTION
 
-nbase is a collection of NetBSD tools portable to Linux, MacOS-X and
+nbase is a collection of NetBSD tools portable to Linux, macOS and
 other UNIX-like systems. Its version looks like x.y.z.n, where x is a
 NetBSD major version, y -- NetBSD minor version, z -- NetBSD patch
 level, and n -- nbase release number. For example, 7.0.0.4 means


### PR DESCRIPTION
The current name of the operating system that runs on Apple's Mac family
of computers is "macOS".