### PR TITLE
Use the more portable unsigned long

### DIFF
--- a/compatlib/mkc_flags_to_string.c
+++ b/compatlib/mkc_flags_to_string.c
@@ -26,14 +26,14 @@
 #include "mkc_macro.h"
 
 #if !defined(HAVE_FUNC2_FLAGS_TO_STRING_UTIL_H)
-char *flags_to_string(u_long flags, const char *def)
+char *flags_to_string(unsigned long flags, const char *def)
 {
 	return __UNCONST("none");
 }
 #endif
 
 #if !defined(HAVE_FUNC3_STRING_TO_FLAGS_UTIL_H)
-int string_to_flags(char **stringp, u_long *setp, u_long *clrp)
+int string_to_flags(char **stringp, unsigned long *setp, unsigned long *clrp)
 {
 	return 0;
 }


### PR DESCRIPTION
I don't have a full explanation for why that became a problem (maybe I was defaulting to -std=c11 rather than -std=gnu11), but this is a pretty reasonable change, IMO.